### PR TITLE
Fix some typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Usage Instructions
 Toolkits
 --------
 
-You can use any supported toolkit united under common API (for reference see `Pybel <https://open-babel.readthedocs.org/en/latest/UseTheLibrary/Python_Pybel.html>`_ or `Cinfony <https://code.google.com/p/cinfony/>`_). All methods and software which based on Pybel/Cinfony should be drop in compatible with ODDT toolkits. In contrast to it’s predecessors, which were aimed to have minimalistic API, ODDT introduces extended methods and additional handles. This extensions allow to use toolkits at all it’s grace and some features may be backported from others to introduce missing functionalities.
+You can use any supported toolkit united under common API (for reference see `Pybel <https://open-babel.readthedocs.org/en/latest/UseTheLibrary/Python_Pybel.html>`_ or `Cinfony <https://code.google.com/p/cinfony/>`_). All methods and software which based on Pybel/Cinfony should be drop in compatible with ODDT toolkits. In contrast to its predecessors, which were aimed to have minimalistic API, ODDT introduces extended methods and additional handles. This extensions allow to use toolkits at all its grace and some features may be backported from others to introduce missing functionalities.
 To name a few:
 
 * coordinates are returned as Numpy Arrays

--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -118,7 +118,7 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     - (Column 6) salt bridges (protein negatively charged)
     - (Column 7) salt bridges (ionic bond with metal ion)
 
-    Returns matrix, which is sorted acordingly to this pattern : 'ALA',
+    Returns matrix, which is sorted according to this pattern : 'ALA',
     'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE', 'LEU',
     'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL', ''.
     The '' means cofactor. Index of amino acid in pattern coresponds


### PR DESCRIPTION
1. Fixed two instances of "it's" --> "its"
2. Fixed "acordingly" --> "according"