### PR TITLE
Introduce cutoff ranges to close_contacts

### DIFF
--- a/oddt/interactions.py
+++ b/oddt/interactions.py
@@ -12,7 +12,7 @@ Currently following interacions are implemented:
 """
 
 import numpy as np
-from oddt.spatial import dihedral, angle, angle_2v, distance
+from oddt.spatial import angle, angle_2v, distance
 
 __all__ = ['close_contacts',
            'hbond_acceptor_donor',
@@ -28,8 +28,10 @@ __all__ = ['close_contacts',
            'pi_metal']
 
 
-def close_contacts(x, y, cutoff, x_column='coords', y_column='coords'):
-    """ Returns pairs of atoms which are within close contac distance cutoff.
+def close_contacts(x, y, cutoff, x_column='coords', y_column='coords',
+                   cutoff_low=0.):
+    """Returns pairs of atoms which are within close contac distance cutoff.
+    The cutoff is semi-inclusive, i.e (cutoff_low, cutoff].
 
         Parameters
         ----------
@@ -43,6 +45,9 @@ def close_contacts(x, y, cutoff, x_column='coords', y_column='coords'):
                 Column containing coordinates of atoms (or pseudo-atoms,
                 i.e. ring centroids)
 
+            cutoff_low : float (default=0.)
+                Lower bound of contacts to find (exclusive). Zero by default.
+
         Returns
         -------
             x_, y_ : atom_dict-type numpy array
@@ -50,7 +55,7 @@ def close_contacts(x, y, cutoff, x_column='coords', y_column='coords'):
     """
     if len(x[x_column]) > 0 and len(x[x_column]) > 0:
         d = distance(x[x_column], y[y_column])
-        index = np.argwhere((d > 0) & (d <= cutoff))
+        index = np.argwhere((d > cutoff_low) & (d <= cutoff))
         return x[index[:, 0]], y[index[:, 1]]
     else:
         return x[[]], y[[]]

--- a/oddt/scoring/descriptors/__init__.py
+++ b/oddt/scoring/descriptors/__init__.py
@@ -111,13 +111,14 @@ class close_contacts_descriptor(object):
                 Flag indicating should permutation of types should be done,
                 otherwise the atoms are treated as aligned pairs.
         """
-        if isinstance(cutoff, (int, float)):
-            self.cutoff = np.array([cutoff])
-        elif len(cutoff) > 1 and len(np.array(cutoff).shape) == 1:
-            self.cutoff = np.vstack((np.array(cutoff)[:-1],
-                                     np.array(cutoff)[1:])).T
-        else:
-            self.cutoff = np.array(cutoff)
+        self.cutoff = np.atleast_1d(cutoff)
+        # Cutoffs in fomr of continuous intervals (0,2,4,6,...)
+        if len(self.cutoff) > 1 and self.cutoff.ndim == 1:
+            self.cutoff = np.vstack((self.cutoff[:-1],
+                                     self.cutoff[1:])).T
+        elif self.cutoff.ndim > 2:
+            raise ValueError('Unsupported shape of cutoff: %s' % self.cutoff.shape)
+
         # for pickle save original value
         self.original_cutoff = cutoff
 
@@ -273,9 +274,7 @@ class autodock_vina_descriptor(object):
                 desc = vec
             else:
                 desc = np.vstack((desc, vec))
-        if len(desc.shape) == 1:
-            desc = desc.reshape(1, -1)
-        return desc
+        return np.atleast_2d(desc)
 
     def __len__(self):
         """ Returns the dimensions of descriptors """
@@ -347,9 +346,7 @@ class oddt_vina_descriptor(object):
                 desc = vec
             else:
                 desc = np.vstack((desc, vec))
-        if len(desc.shape) == 1:
-            desc = desc.reshape(1, -1)
-        return desc
+        return np.atleast_2d(desc)
 
     def __len__(self):
         """ Returns the dimensions of descriptors """

--- a/oddt/scoring/descriptors/__init__.py
+++ b/oddt/scoring/descriptors/__init__.py
@@ -4,7 +4,7 @@ from scipy.spatial.distance import cdist as distance
 from oddt.docking import autodock_vina
 from oddt.docking.internal import vina_docking
 
-__all__ = ['close_contacts',
+__all__ = ['close_contacts_descriptor',
            'fingerprints',
            'autodock_vina_descriptor',
            'oddt_vina_descriptor']
@@ -77,7 +77,7 @@ def atoms_by_type(atom_dict, types, mode='atomic_nums'):
     return out
 
 
-class close_contacts(object):
+class close_contacts_descriptor(object):
     def __init__(self,
                  protein=None,
                  cutoff=4,
@@ -201,12 +201,12 @@ class close_contacts(object):
             return len(self.ligand_types) * len(self.protein_types) * len(self.cutoff)
 
     def __reduce__(self):
-        return close_contacts, (self.protein,
-                                self.original_cutoff,
-                                self.mode,
-                                self.ligand_types,
-                                self.protein_types,
-                                self.aligned_pairs)
+        return close_contacts_descriptor, (self.protein,
+                                           self.original_cutoff,
+                                           self.mode,
+                                           self.ligand_types,
+                                           self.protein_types,
+                                           self.aligned_pairs)
 
 
 # TODO: we don't use toolkit. should we?

--- a/oddt/scoring/functions/RFScore.py
+++ b/oddt/scoring/functions/RFScore.py
@@ -14,7 +14,8 @@ from oddt import random_seed
 from oddt.metrics import rmse
 from oddt.scoring import scorer, ensemble_descriptor
 from oddt.scoring.models.regressors import randomforest
-from oddt.scoring.descriptors import close_contacts, oddt_vina_descriptor
+from oddt.scoring.descriptors import (close_contacts_descriptor,
+                                      oddt_vina_descriptor)
 
 
 # numpy after pickling gives Runtime Warnings
@@ -35,24 +36,27 @@ class rfscore(scorer):
         if version == 1:
             cutoff = 12
             mtry = 6
-            descriptors = close_contacts(protein,
-                                         cutoff=cutoff,
-                                         protein_types=protein_atomic_nums,
-                                         ligand_types=ligand_atomic_nums)
+            descriptors = close_contacts_descriptor(
+                protein,
+                cutoff=cutoff,
+                protein_types=protein_atomic_nums,
+                ligand_types=ligand_atomic_nums)
         elif version == 2:
             cutoff = np.array([0, 2, 4, 6, 8, 10, 12])
             mtry = 14
-            descriptors = close_contacts(protein,
-                                         cutoff=cutoff,
-                                         protein_types=protein_atomic_nums,
-                                         ligand_types=ligand_atomic_nums)
+            descriptors = close_contacts_descriptor(
+                protein,
+                cutoff=cutoff,
+                protein_types=protein_atomic_nums,
+                ligand_types=ligand_atomic_nums)
         elif version == 3:
             cutoff = 12
             mtry = 6
-            cc = close_contacts(protein,
-                                cutoff=cutoff,
-                                protein_types=protein_atomic_nums,
-                                ligand_types=ligand_atomic_nums)
+            cc = close_contacts_descriptor(
+                protein,
+                cutoff=cutoff,
+                protein_types=protein_atomic_nums,
+                ligand_types=ligand_atomic_nums)
             vina_scores = ['vina_gauss1',
                            'vina_gauss2',
                            'vina_repulsion',

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -36,7 +36,7 @@ def test_atoms_by_type():
             assert_equal(len(types_dict[t]), n)
 
 
-def test_close_contacts():
+def test_close_contacts_descriptor():
     ligands = list(oddt.toolkit.readfile('sdf', actives_sdf))
     rec = next(oddt.toolkit.readfile('pdb', receptor_pdb))
     rec.protein = True
@@ -44,7 +44,7 @@ def test_close_contacts():
 
     for cutoff, num_contacts in ((4, 6816), ([4], 6816), ([2, 4], 6816),
                                  ([[1, 2], [3, 4]], 6304)):
-        contacts_descriptor = descriptors.close_contacts(
+        contacts_descriptor = descriptors.close_contacts_descriptor(
             cutoff=cutoff,
             ligand_types=[6, 7, 8],
             protein_types=[6, 7, 8])


### PR DESCRIPTION
This PR make ranges of (2,4] possible with `close_contacts` (previously lower bound always was 0). Additionally it removes name duplicate of descriptor generator.