### PR TITLE
Warn in Vina about empty coords. Fixes #62

### DIFF
--- a/oddt/docking/AutodockVina.py
+++ b/oddt/docking/AutodockVina.py
@@ -8,7 +8,9 @@ import re
 import os
 
 import oddt
-from oddt.utils import is_openbabel_molecule, is_molecule
+from oddt.utils import (is_openbabel_molecule,
+                        is_molecule,
+                        check_molecule)
 from oddt.spatial import rmsd
 
 
@@ -192,6 +194,7 @@ class autodock_vina(object):
         ligand_dir = mkdtemp(dir=self.tmp_dir, prefix='ligands_')
         output_array = []
         for n, ligand in enumerate(ligands):
+            check_molecule(ligand, force_coords=True)
             ligand_file = write_vina_pdbqt(ligand, ligand_dir, name_id=n)
             try:
                 scores = parse_vina_scoring_output(
@@ -237,6 +240,7 @@ class autodock_vina(object):
         ligand_dir = mkdtemp(dir=self.tmp_dir, prefix='ligands_')
         output_array = []
         for n, ligand in enumerate(ligands):
+            check_molecule(ligand, force_coords=True)
             ligand_file = write_vina_pdbqt(ligand, ligand_dir, name_id=n)
             ligand_outfile = ligand_file[:-6] + '_out.pdbqt'
             try:

--- a/oddt/utils.py
+++ b/oddt/utils.py
@@ -1,4 +1,5 @@
 """Common utilities for ODDT"""
+import numpy as np
 import oddt
 
 
@@ -18,3 +19,48 @@ def is_rdkit_molecule(obj):
     """Check whether an object is an `oddt.toolkits.rdk.Molecule` instance."""
     return (hasattr(oddt.toolkits, 'rdk') and
             isinstance(obj, oddt.toolkits.rdk.Molecule))
+
+
+def check_molecule(mol,
+                   force_protein=False,
+                   force_coords=False,
+                   non_zero_atoms=False):
+    """Universal validator of molecule objects. Usage of positional arguments is
+    allowed only for molecule object, otherwise it is prohibitted (i.e. the
+    order of arguments **will** change). Desired properties of molecule are
+    validated based on specified arguments. By default only the object type is
+    checked. In case of discrepancy to the specification a `ValueError` is
+    raised with appropriate message.
+
+    Parameters
+    ----------
+        mol: oddt.toolkit.Molecule object
+            Object to verify
+
+        force_protein: bool (default=False)
+            Force the molecule to be marked as protein (mol.protein).
+
+        force_coords: bool (default=False)
+            Force the molecule to have non-zero coordinates.
+
+        non_zero_atoms: bool (default=False)
+            Check if molecule has at least one atom.
+
+    """
+    # TODO 2to3 force only one positional argument by adding * to args
+    if not is_molecule(mol):
+        raise ValueError('Molecule object was expected, insted got: %s'
+                         % str(mol))
+
+    if force_protein and not mol.protein:
+        raise ValueError('Molecule "%s" is not marked as a protein. Mark it by '
+                         'setting the protein property to `True` (`mol.protein '
+                         '= True)' % mol.title)
+
+    if force_coords and (not mol.coords.any() or
+                         np.isnan(mol.coords).any()):
+        raise ValueError('Molecule "%s" has no 3D coordinates. All atoms are '
+                         'located at (0, 0, 0).' % mol.title)
+
+    if non_zero_atoms and len(mol.atoms) == 0:
+        raise ValueError('Molecule "%s" has zero atoms.' % mol.title)

--- a/oddt/virtualscreening.py
+++ b/oddt/virtualscreening.py
@@ -9,6 +9,7 @@ from os.path import dirname, isfile
 from multiprocessing import Pool  # process
 from itertools import chain
 from functools import partial
+import warnings
 
 from oddt import toolkit
 from oddt.scoring import scorer
@@ -321,8 +322,9 @@ class virtualscreening:
             self._pipe = sf.predict_ligands(self._pipe)
 
     def fetch(self):
-        for n, mol in enumerate(self._pipe):
-            self.num_output = n+1
+        """A method to exhaust the pipeline. Itself it is lazy (a generator)"""
+        for mol in self._pipe:
+            self.num_output += 1
             if self.verbose and self.num_input % 100 == 0:
                 print("Passed: %i (%.2f%%)\tTotal: %i\r" %
                       (self.num_output,
@@ -332,6 +334,9 @@ class virtualscreening:
             yield mol
         if self.verbose:
             print('', file=sys.stderr)
+        if self.num_output == 0:
+            warnings.warn('There is **zero** molecules at the output of the VS'
+                          ' pipeline. Output file will be empty.')
 
     # Consume the pipe
     def write(self, fmt, filename, csv_filename=None, **kwargs):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+import os
+from sklearn.utils.testing import assert_raises_regexp
+
+import oddt
+from oddt.utils import check_molecule
+
+test_data_dir = os.path.dirname(os.path.abspath(__file__))
+
+# common file names
+dude_data_dir = os.path.join(test_data_dir, 'data', 'dude', 'xiap')
+xiap_crystal_ligand = os.path.join(dude_data_dir, 'crystal_ligand.sdf')
+xiap_protein = os.path.join(dude_data_dir, 'receptor_rdkit.pdb')
+
+
+def test_check_molecule():
+    assert_raises_regexp(ValueError, 'Molecule object', check_molecule, [])
+
+    ligand = next(oddt.toolkit.readfile('sdf', xiap_crystal_ligand))
+    check_molecule(ligand)
+
+    # force protein
+    protein = next(oddt.toolkit.readfile('pdb', xiap_protein))
+    assert_raises_regexp(ValueError,
+                         'marked as a protein',
+                         check_molecule,
+                         protein,
+                         force_protein=True)
+
+    protein.protein = True
+    check_molecule(protein, force_protein=True)
+
+    # force coordinates
+    mol = oddt.toolkit.readstring('smi', 'c1ccccc1')
+    assert_raises_regexp(ValueError,
+                         '3D coordinates',
+                         check_molecule,
+                         mol,
+                         force_coords=True)
+    mol.make3D()
+    check_molecule(mol, force_coords=True)
+
+    #assert_raises_regexp(ValueError, 'positional', check_molecule, mol, True)
+
+    mol = oddt.toolkit.readstring('sdf', '''mol_title
+ handmade
+
+  0  0  0  0  0  0  0  0  0  0999 V2000
+M  END
+                          ''')
+    assert_raises_regexp(ValueError,
+                         'has zero atoms',
+                         check_molecule,
+                         mol,
+                         non_zero_atoms=True)

--- a/tests/test_virtualscreening.py
+++ b/tests/test_virtualscreening.py
@@ -4,7 +4,8 @@ from tempfile import mkdtemp, NamedTemporaryFile
 from nose.tools import assert_in, assert_equal
 from sklearn.utils.testing import (assert_array_equal,
                                    assert_array_almost_equal,
-                                   assert_raises)
+                                   assert_raises,
+                                   assert_raises_regexp)
 
 import pandas as pd
 
@@ -87,6 +88,23 @@ def test_vs_docking():
 
         assert_array_almost_equal([rmsd(ref_mol, mol, method='min_symmetry')
                                    for mol in mols], vina_rmsd)
+
+
+def test_vs_docking_empty():
+    vs = virtualscreening(n_cpu=1)
+    vs.load_ligands('smi', os.path.join(dude_data_dir, 'actives_rdkit.smi'))
+
+    vs.dock(engine='autodock_vina',
+            protein=xiap_protein,
+            auto_ligand=xiap_crystal_ligand,
+            exhaustiveness=1,
+            energy_range=5,
+            num_modes=9,
+            size=(20, 20, 20),
+            seed=0)
+
+    assert_raises_regexp(ValueError, 'has no 3D coordinates',
+                         next, vs.fetch())
 
 
 if oddt.toolkit.backend == 'ob':  # RDKit rewrite needed


### PR DESCRIPTION
This PR fixes #62 and also warns if there is no molecules at the output of VS pipeline.