### PR TITLE
Rewrite VS pipelines to use chunks

### DIFF
--- a/bin/oddt_cli
+++ b/bin/oddt_cli
@@ -50,19 +50,31 @@ from oddt.scoring import scorer
 
 def main():
     # arguments
-    parser = argparse.ArgumentParser(description='Open Drug Discovery (ODDT) command line tools')
+    parser = argparse.ArgumentParser(
+        description='Open Drug Discovery (ODDT) command line tools')
     parser.add_argument('--toolkit',
                         dest='toolkit',
                         choices=['ob', 'rdk'],
                         default='ob',
-                        help='Choose which toolkit should be used for calculations, either "ob" (OpenBabel) or "rdkit" (RDKit) (default: ob)')
+                        help=('Choose which toolkit should be used for '
+                              'calculations, either "ob" (OpenBabel) or '
+                              '"rdkit" (RDKit) (default: ob)'))
     parser.add_argument('-n', '--n_cpu',
                         dest='n_cpu',
                         type=int,
-                        help='The number of parallel processes. -1 automatically assigns maximum number of CPUs. (default=-1)')
+                        help=('The number of parallel processes. '
+                              '-1 automatically assigns maximum number of CPUs.'
+                              ' (default=-1)'))
     parser.add_argument('--version',
                         action='version',
                         version='%(prog)s ' + oddt.__version__)
+
+    parser.add_argument('-c', '--chunksize',
+                        dest='chunksize',
+                        type=int,
+                        default=100,
+                        help=('The number of molecules to process in a chunk. '
+                              ' (default=100)'))
 
     # in/out files and formats
     parser.add_argument('in_file', nargs='+',
@@ -77,7 +89,8 @@ def main():
                        dest='filter',
                        action='append',
                        default=[],
-                       help='Choose built-in filters to be used (eg. "ro5", "ro3", "pains")')
+                       help=('Choose built-in filters to be used (eg. "ro5", '
+                             '"ro3", "pains")'))
 
     # fingerprints
     group = parser.add_argument_group('Similarity searching')
@@ -93,7 +106,8 @@ def main():
                        dest='cutoff',
                        type=float,
                        default=0.9,
-                       help='Similarity cufoff below which molecules will be ignored.')
+                       help=('Similarity cufoff below which molecules will be'
+                             ' ignored.'))
 
     group.add_argument('--query',
                        dest='query',
@@ -107,10 +121,14 @@ def main():
                        choices=['autodock_vina'],
                        help='Choose docking software to be used')
     group.add_argument('--receptor', help='Protein file')
-    group.add_argument('--auto_ligand', help='Docking Box is determined on that ligand')
-    group.add_argument('--center', type=literal_eval, help='Docking Box center (x,y,z)')
-    group.add_argument('--size', type=literal_eval, help='Docking Box dimentions  (x,y,z)')
-    group.add_argument('--exhaustiveness', default=8, type=int, help='Exhaustiveness of docking')
+    group.add_argument('--auto_ligand',
+                       help='Docking Box is determined on that ligand')
+    group.add_argument('--center', type=literal_eval,
+                       help='Docking Box center (x,y,z)')
+    group.add_argument('--size', type=literal_eval,
+                       help='Docking Box dimentions  (x,y,z)')
+    group.add_argument('--exhaustiveness', default=8, type=int,
+                       help='Exhaustiveness of docking')
     group.add_argument('--seed', help='Random Seed')
 
     # scoring
@@ -141,7 +159,8 @@ def main():
                         dest='save_fields',
                         action='append',
                         default=[],
-                        help='Field to save (eg. in CSV). Each field should be specified separately.')
+                        help=('Field to save (eg. in CSV). Each field should be'
+                              ' specified separately.'))
 
     args = parser.parse_args()
 
@@ -158,7 +177,8 @@ def main():
     from oddt.virtualscreening import virtualscreening as vs
 
     # Create pipeline for docking and rescoring
-    pipeline = vs(n_cpu=args.n_cpu if 'n_cpu' in args else -1)
+    pipeline = vs(n_cpu=args.n_cpu if 'n_cpu' in args else -1,
+                  chunksize=args.chunksize)
     for f in args.in_file:
         if args.in_format:
             fmt = args.in_format

--- a/oddt/scoring/functions/NNScore.py
+++ b/oddt/scoring/functions/NNScore.py
@@ -6,8 +6,9 @@ import warnings
 from joblib import Parallel, delayed
 
 from oddt import random_seed
+from oddt.utils import method_caller
 from oddt.metrics import rmse
-from oddt.scoring import scorer, ensemble_model, _parallel_helper
+from oddt.scoring import scorer, ensemble_model
 from oddt.scoring.descriptors.binana import binana_descriptor
 from oddt.scoring.models.regressors import neuralnetwork
 
@@ -55,7 +56,7 @@ class nnscore(scorer):
         seeds = np.random.randint(123456789, size=n)
         trained_nets = (
             Parallel(n_jobs=self.n_jobs, verbose=10, pre_dispatch='all')(
-                delayed(_parallel_helper)(
+                delayed(method_caller)(
                     neuralnetwork((5,),
                                   random_state=seeds[i],
                                   activation='logistic',

--- a/oddt/utils.py
+++ b/oddt/utils.py
@@ -1,5 +1,7 @@
 """Common utilities for ODDT"""
 from itertools import islice
+from types import GeneratorType
+
 import numpy as np
 import oddt
 
@@ -76,13 +78,18 @@ def compose_iter(iterable, funcs):
 
 
 def chunker(iterable, chunksize=100):
-    """Generate chunks from iterable"""
+    """Generate chunks from a generator object. If iterable is passed which is
+    not a generator it will be converted to one with `iter()`."""
+    # ensure it is a generator
+    if not isinstance(iterable, GeneratorType):
+        iterable = iter(iterable)
     chunk = list(islice(iterable, chunksize))
     while chunk:
         yield chunk
         chunk = list(islice(iterable, chunksize))
 
 
+# TODO 2to3 remove it when support for Python 2.7 is dropped
 def method_caller(obj, methodname, *args, **kwargs):
     """Helper function to workaround Python 2 pickle limitations to parallelize
     methods and generator objects"""

--- a/oddt/utils.py
+++ b/oddt/utils.py
@@ -1,4 +1,5 @@
 """Common utilities for ODDT"""
+from itertools import islice
 import numpy as np
 import oddt
 
@@ -64,3 +65,25 @@ def check_molecule(mol,
 
     if non_zero_atoms and len(mol.atoms) == 0:
         raise ValueError('Molecule "%s" has zero atoms.' % mol.title)
+
+
+def compose_iter(iterable, funcs):
+    """Chain functions and apply them to iterable, by exhausting the iterable.
+    Functions are executed in the order from funcs."""
+    for func in funcs:
+        iterable = func(iterable)
+    return list(iterable)
+
+
+def chunker(iterable, chunksize=100):
+    """Generate chunks from iterable"""
+    chunk = list(islice(iterable, chunksize))
+    while chunk:
+        yield chunk
+        chunk = list(islice(iterable, chunksize))
+
+
+def method_caller(obj, methodname, *args, **kwargs):
+    """Helper function to workaround Python 2 pickle limitations to parallelize
+    methods and generator objects"""
+    return getattr(obj, methodname)(*args, **kwargs)

--- a/oddt/virtualscreening.py
+++ b/oddt/virtualscreening.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import csv
-from os.path import dirname, isfile
+from os.path import dirname, isfile, join
 from multiprocessing import Pool
 from itertools import chain
 from functools import partial
@@ -143,7 +143,7 @@ class virtualscreening:
                                                        'mol.logP <= 5'],
                                            soft_fail=soft_fail)))
             # Rule of three
-            elif expression.lower() in ['ro3']:
+            elif expression.lower() == 'ro3':
                 self._pipe.append((partial(_filter,
                                            expression=['mol.molwt < 300',
                                                        'mol.HBA1 <= 3',
@@ -151,9 +151,10 @@ class virtualscreening:
                                                        'mol.logP <= 3'],
                                            soft_fail=soft_fail)))
             # PAINS filter
-            elif expression.lower() in ['pains']:
+            elif expression.lower() == 'pains':
                 pains_smarts = {}
-                with open(dirname(__file__) + '/filter/pains.smarts') as pains_file:
+                with open(join(dirname(__file__),
+                               'filter', 'pains.smarts')) as pains_file:
                     csv_reader = csv.reader(pains_file, delimiter="\t")
                     for line in csv_reader:
                         if len(line) > 1:
@@ -218,10 +219,11 @@ class virtualscreening:
             dist = usr_similarity
         else:
             raise ValueError('Similarity filter "%s" is not supported.' % method)
+        # generate FPs for query molecules once
         query_fps = [gen(q) for q in query]
         self._pipe.append(partial(_filter_similarity,
                                   distance=dist,
-                                  generator=gen,
+                                  generator=gen,  # same generator for pipe mols
                                   query_fps=query_fps,
                                   cutoff=cutoff))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 import os
-from sklearn.utils.testing import assert_raises_regexp
+from sklearn.utils.testing import assert_raises_regexp, assert_equal
 
 import oddt
-from oddt.utils import check_molecule
+from oddt.utils import check_molecule, chunker, compose_iter
 
 test_data_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -52,3 +52,20 @@ M  END
                          check_molecule,
                          mol,
                          non_zero_atoms=True)
+
+
+def test_func_composition():
+    def double(x):
+        return [i * 2 for i in x]
+
+    def inc(x):
+        return [i + 1 for i in x]
+
+    assert_equal(compose_iter([1], funcs=[double, inc]), [3])
+    assert_equal(compose_iter([3], funcs=[double, inc]), [7])
+    assert_equal(compose_iter([10], funcs=[double, inc]), [21])
+
+
+def test_chunks():
+    chunks = chunker(iter('ABCDEFG'), 2)
+    assert_equal(list(chunks), [['A', 'B'], ['C', 'D'], ['E', 'F'], ['G']])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,5 +67,5 @@ def test_func_composition():
 
 
 def test_chunks():
-    chunks = chunker(iter('ABCDEFG'), 2)
+    chunks = chunker('ABCDEFG', 2)
     assert_equal(list(chunks), [['A', 'B'], ['C', 'D'], ['E', 'F'], ['G']])

--- a/tests/test_virtualscreening.py
+++ b/tests/test_virtualscreening.py
@@ -103,7 +103,7 @@ def test_vs_docking_empty():
             size=(20, 20, 20),
             seed=0)
 
-    assert_raises_regexp(ValueError, 'has no 3D coordinates', vs.fetch)
+    assert_raises_regexp(ValueError, 'has no 3D coordinates', next, vs.fetch())
 
 
 if oddt.toolkit.backend == 'ob':  # RDKit rewrite needed

--- a/tests/test_virtualscreening.py
+++ b/tests/test_virtualscreening.py
@@ -200,7 +200,7 @@ def test_vs_scoring():
             model.gen_training_data(data_dir, pdbbind_versions=pdbbind_versions,
                                     home_dir=home_dir)
             filenames.append(model.train(home_dir=home_dir))
-    vs = virtualscreening(n_cpu=1, chunksize=10)
+    vs = virtualscreening(n_cpu=-1, chunksize=10)
     vs.load_ligands('sdf', xiap_actives_docked)
     # error if no protein is fed
     assert_raises(ValueError, vs.score, 'nnscore')
@@ -228,7 +228,7 @@ def test_vs_scoring():
     assert_in('rfscore_v2', mol_data)
     assert_in('rfscore_v3', mol_data)
 
-    vs = virtualscreening(n_cpu=1, chunksize=10)
+    vs = virtualscreening(n_cpu=-1, chunksize=10)
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.score('nnscore', protein=protein)
     vs.score('rfscore_v1', protein=protein)

--- a/tests/test_virtualscreening.py
+++ b/tests/test_virtualscreening.py
@@ -103,14 +103,13 @@ def test_vs_docking_empty():
             size=(20, 20, 20),
             seed=0)
 
-    assert_raises_regexp(ValueError, 'has no 3D coordinates',
-                         next, vs.fetch())
+    assert_raises_regexp(ValueError, 'has no 3D coordinates', vs.fetch)
 
 
 if oddt.toolkit.backend == 'ob':  # RDKit rewrite needed
     def test_vs_filtering():
         """VS preset filtering tests"""
-        vs = virtualscreening(n_cpu=-1)
+        vs = virtualscreening(n_cpu=1)
 
         vs.load_ligands('sdf', xiap_actives_docked)
         vs.apply_filter('ro5', soft_fail=1)
@@ -123,7 +122,7 @@ if oddt.toolkit.backend == 'ob':  # RDKit rewrite needed
 
 def test_vs_pains():
     """VS PAINS filter tests"""
-    vs = virtualscreening(n_cpu=-1)
+    vs = virtualscreening(n_cpu=1)
     # TODO: add some failing molecules
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.apply_filter('pains', soft_fail=0)
@@ -136,7 +135,7 @@ def test_vs_similarity():
     receptor = next(oddt.toolkit.readfile('pdb', xiap_protein))
 
     # following toolkit differences is due to different Hs treatment
-    vs = virtualscreening(n_cpu=-1)
+    vs = virtualscreening(n_cpu=1, chunksize=10)
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.similarity('usr', cutoff=0.4, query=ref_mol)
     if oddt.toolkit.backend == 'ob':
@@ -144,7 +143,7 @@ def test_vs_similarity():
     else:
         assert_equal(len(list(vs.fetch())), 6)
 
-    vs = virtualscreening(n_cpu=-1)
+    vs = virtualscreening(n_cpu=1)
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.similarity('usr_cat', cutoff=0.3, query=ref_mol)
     if oddt.toolkit.backend == 'ob':
@@ -152,7 +151,7 @@ def test_vs_similarity():
     else:
         assert_equal(len(list(vs.fetch())), 11)
 
-    vs = virtualscreening(n_cpu=-1)
+    vs = virtualscreening(n_cpu=1)
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.similarity('electroshape', cutoff=0.45, query=ref_mol)
     if oddt.toolkit.backend == 'ob':
@@ -201,7 +200,7 @@ def test_vs_scoring():
             model.gen_training_data(data_dir, pdbbind_versions=pdbbind_versions,
                                     home_dir=home_dir)
             filenames.append(model.train(home_dir=home_dir))
-    vs = virtualscreening(n_cpu=1)
+    vs = virtualscreening(n_cpu=1, chunksize=10)
     vs.load_ligands('sdf', xiap_actives_docked)
     # error if no protein is fed
     assert_raises(ValueError, vs.score, 'nnscore')
@@ -229,7 +228,7 @@ def test_vs_scoring():
     assert_in('rfscore_v2', mol_data)
     assert_in('rfscore_v3', mol_data)
 
-    vs = virtualscreening(n_cpu=1)
+    vs = virtualscreening(n_cpu=1, chunksize=10)
     vs.load_ligands('sdf', xiap_actives_docked)
     vs.score('nnscore', protein=protein)
     vs.score('rfscore_v1', protein=protein)


### PR DESCRIPTION
VS pipelines will move `chunksize` of molecules at a time. The idea is to lower cost of pickling objects for every molecule. Finally we should have at best `n_cpus * chunksize` molecules in memory.
Missing bits:

- [x] make executing loop in `fetch()` method lazy
- [x] ensure that there is max `n_cpus * chunksize` molecules in memory
- [x] introduce chunksize to `oddt_cli`