### PR TITLE
Fix (Simple) Interaction Fingerprints

### DIFF
--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -161,8 +161,8 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
         rings[strict_parallel]['resname'], amino_acids)] = ''
     np.add.at(IFP, [np.searchsorted(
         amino_acids, np.sort(rings[strict_parallel]['resname'])[::-1]), 1], 1)
-    rings[strict_parallel]['resname'][~np.in1d(rings[strict_perpendicular]
-                                               ['resname'], amino_acids)] = ''
+    rings[strict_perpendicular]['resname'][~np.in1d(
+        rings[strict_perpendicular]['resname'], amino_acids)] = ''
     np.add.at(IFP, [np.searchsorted(
         amino_acids,
         np.sort(rings[strict_perpendicular]['resname'])[::-1]), 2], 1)

--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -64,42 +64,44 @@ def InteractionFingerprint(ligand, protein, strict=True):
 
     # hydrophobic contacts (column = 0)
     hydrophobic = hydrophobic_contacts(protein, ligand)[0]['resid']
-    np.add.at(IFP, [np.searchsorted(resids, hydrophobic), 0], 1)
+    np.add.at(IFP, [np.searchsorted(resids, np.sort(hydrophobic)[::-1]), 0], 1)
 
     # aromatic face to face (Column = 1), aromatic edge to face (Column = 2)
     rings, _, strict_parallel, strict_perpendicular = pi_stacking(
         protein, ligand)
     np.add.at(IFP, [np.searchsorted(
-        resids, rings[strict_parallel]['resid']), 1], 1)
+        resids, np.sort(rings[strict_parallel]['resid'])[::-1]), 1], 1)
     np.add.at(IFP, [np.searchsorted(
-        resids, rings[strict_perpendicular]['resid']), 2], 1)
+        resids, np.sort(rings[strict_perpendicular]['resid'])[::-1]), 2], 1)
 
     # h-bonds, protein as a donor (Column = 3)
     _, donors, strict0 = hbond_acceptor_donor(ligand, protein)
     if strict is False:
         strict0 = None
-    np.add.at(IFP, [np.searchsorted(resids, donors[strict0]['resid']), 3], 1)
+    np.add.at(IFP, [np.searchsorted(
+        resids, np.sort(donors[strict0]['resid'])[::-1]), 3], 1)
 
     # h-bonds, protein as an acceptor (Column = 4)
     acceptors, _, strict1 = hbond_acceptor_donor(protein, ligand)
     if strict is False:
         strict1 = None
     np.add.at(IFP, [np.searchsorted(
-        resids, acceptors[strict1]['resid']), 4], 1)
+        resids, np.sort(acceptors[strict1]['resid'])[::-1]), 4], 1)
 
     # salt bridges, protein positively charged (Column = 5)
     plus, _ = salt_bridge_plus_minus(protein, ligand)
-    np.add.at(IFP, [np.searchsorted(resids, plus['resid']), 5], 1)
+    np.add.at(IFP, [np.searchsorted(resids, np.sort(plus['resid'])[::-1]), 5], 1)
 
     # salt bridges, protein negatively charged (Colum = 6)
     _, minus = salt_bridge_plus_minus(ligand, protein)
-    np.add.at(IFP, [np.searchsorted(resids, minus['resid']), 6], 1)
+    np.add.at(IFP, [np.searchsorted(resids, np.sort(minus['resid'])[::-1]), 6], 1)
 
     # salt bridges, ionic bond with metal ion (Column = 7)
     _, metal, strict2 = acceptor_metal(protein, ligand)
     if strict is False:
         strict2 = None
-    np.add.at(IFP, [np.searchsorted(resids, metal[strict2]['resid']), 7], 1)
+    np.add.at(IFP, [np.searchsorted(
+        resids, np.sort(metal[strict2]['resid'])[::-1]), 7], 1)
 
     return IFP.flatten()
 
@@ -149,7 +151,8 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     # hydrophobic (Column = 0)
     hydrophobic = hydrophobic_contacts(protein, ligand)[0]['resname']
     hydrophobic[~np.in1d(hydrophobic, amino_acids)] = ''
-    np.add.at(IFP, [np.searchsorted(amino_acids, hydrophobic), 0], 1)
+    np.add.at(IFP, [np.searchsorted(amino_acids,
+                                    np.sort(hydrophobic)[::-1]), 0], 1)
 
     # aromatic face to face (Column = 1), aromatic edge to face (Column = 2)
     rings, _, strict_parallel, strict_perpendicular = pi_stacking(
@@ -157,11 +160,12 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     rings[strict_parallel]['resname'][~np.in1d(
         rings[strict_parallel]['resname'], amino_acids)] = ''
     np.add.at(IFP, [np.searchsorted(
-        amino_acids, rings[strict_parallel]['resname']), 1], 1)
+        amino_acids, np.sort(rings[strict_parallel]['resname'])[::-1]), 1], 1)
     rings[strict_parallel]['resname'][~np.in1d(rings[strict_perpendicular]
                                                ['resname'], amino_acids)] = ''
     np.add.at(IFP, [np.searchsorted(
-        amino_acids, rings[strict_perpendicular]['resname']), 2], 1)
+        amino_acids,
+        np.sort(rings[strict_perpendicular]['resname'])[::-1]), 2], 1)
 
     # hbonds donated by the protein (Column = 3)
     _, donors, strict0 = hbond_acceptor_donor(ligand, protein)
@@ -169,7 +173,7 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     if strict is False:
         strict0 = None
     np.add.at(IFP, [np.searchsorted(
-        amino_acids, donors[strict0]['resname']), 3], 1)
+        amino_acids, np.sort(donors[strict0]['resname'])[::-1]), 3], 1)
 
     # hbonds donated by the ligand (Column = 4)
     acceptors, _, strict1 = hbond_acceptor_donor(protein, ligand)
@@ -177,17 +181,19 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     if strict is False:
         strict1 = None
     np.add.at(IFP, [np.searchsorted(
-        amino_acids, acceptors[strict1]['resname']), 4], 1)
+        amino_acids, np.sort(acceptors[strict1]['resname'])[::-1]), 4], 1)
 
     # ionic bond with protein cation(Column = 5)
     plus, _ = salt_bridge_plus_minus(protein, ligand)
     plus['resname'][~np.in1d(plus['resname'], amino_acids)] = ''
-    np.add.at(IFP, [np.searchsorted(amino_acids, plus['resname']), 5], 1)
+    np.add.at(IFP, [np.searchsorted(amino_acids,
+                                    np.sort(plus['resname'])[::-1]), 5], 1)
 
     # ionic bond with protein anion(Column = 6)
     _, minus = salt_bridge_plus_minus(ligand, protein)
     minus['resname'][~np.in1d(minus['resname'], amino_acids)] = ''
-    np.add.at(IFP, [np.searchsorted(amino_acids, minus['resname']), 6], 1)
+    np.add.at(IFP, [np.searchsorted(amino_acids,
+                                    np.sort(minus['resname'])[::-1]), 6], 1)
 
     # ionic bond with metal ion (Column = 7)
     _, metal, strict2 = acceptor_metal(protein, ligand)
@@ -195,7 +201,7 @@ def SimpleInteractionFingerprint(ligand, protein, strict=True):
     if strict is False:
         strict2 = None
     np.add.at(IFP, [np.searchsorted(
-        amino_acids, metal[strict2]['resname']), 7], 1)
+        amino_acids, np.sort(metal[strict2]['resname'])[::-1]), 7], 1)
 
     return IFP.flatten()
 


### PR DESCRIPTION
There was a problem with SIFP that led to `IndexError` for multiple interacting residues, which is now fixed. Also there was a small bug in SIFP that mixed pi-stacking perpendicular and parallel interactions.