### PR TITLE
Bump scipy and numpy requirements. Add Py3.5 minimal req test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
         # Minimal required package versions
         - ODDT_TOOLKIT=ob CONDA_PY=2.7 MINIMAL_REQ=1
         - ODDT_TOOLKIT=rdk CONDA_PY=2.7  MINIMAL_REQ=1
+        - ODDT_TOOLKIT=ob CONDA_PY=3.5 MINIMAL_REQ=1
+        - ODDT_TOOLKIT=rdk CONDA_PY=3.5  MINIMAL_REQ=1
         # Recent versions
         - ODDT_TOOLKIT=ob CONDA_PY=2.7
         - ODDT_TOOLKIT=ob CONDA_PY=3.5
@@ -56,12 +58,12 @@ install:
     - source activate test-environment
     - |
         if [[ "$MINIMAL_REQ" == "1" ]]; then
-            conda install -q -c anaconda numpy=1.8.2 scipy=0.14 joblib=0.8 xlsxwriter;
-            pip install scikit-learn==0.18 scikit-image==0.12.3 pandas==0.17.1 --no-binary=pandas;
+            conda install -q -c anaconda numpy=1.11 numpy-base=1.11 scipy=0.17.0 joblib=0.9.4 scikit-image=0.12.3 xlsxwriter \
+                scikit-learn=0.18 pandas=0.19.2;
             if [[ "$ODDT_TOOLKIT" == "ob" ]]; then
                 conda install -q -c oddt/label/travis openbabel=2.3.2;
             elif [[ "$ODDT_TOOLKIT" == "rdk" ]]; then
-                conda install -q -c oddt/label/travis rdkit=2016.03 numpy=1.8;
+                conda install -q -c rdkit rdkit=2016.03.4 numpy=1.11;
             fi
         else
             conda install -q -c anaconda numpy "scipy<1.3" scikit-learn joblib pandas scikit-image xlsxwriter;

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Open Drug Discovery Toolkit (ODDT) is modular and comprehensive toolkit for use 
 ## Requrements
   * Python 2.7 or 3.5+
   * OpenBabel (2.3.2+) or/and RDKit (2016.03)
-  * Numpy (1.8+)
-  * Scipy (0.14+)
+  * Numpy (1.11+)
+  * Scipy (0.17+)
   * Sklearn (0.18+)
-  * joblib (0.8+)
-  * pandas (0.17.1+)
-  * Skimage (0.10+) (optional, only for surface generation)
+  * joblib (0.9.4+)
+  * pandas (0.19.2+)
+  * Skimage (0.12.3+) (optional, only for surface generation)
 
 ## Install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpydoc
 six
-numpy>=1.8
-scipy>=0.14
+numpy>=1.11
+scipy>=0.17
 scikit-learn>=0.18
-joblib>=0.8
-pandas>=0.17.1
+joblib>=0.9.4
+pandas>=0.19.2


### PR DESCRIPTION
This adjusts the requirements for 3.5 and prepares for the inevitable. 