### PR TITLE
Add option to generate bits info for PLEC fingerprints

### DIFF
--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -863,11 +863,15 @@ def PLEC(ligand, protein, depth_ligand=2, depth_protein=4, distance_cutoff=4.5,
                 ))
 
     # folding and sorting
-    plec = np.sort(fold(np.array(result), size=size)).astype(np.min_scalar_type(size))
+    plec = fold(np.array(result), size=size)
+    sort_indexes = np.argsort(plec)
+    plec = plec[sort_indexes].astype(np.min_scalar_type(size))
 
     # add bits info after folding
     if bits_info is not None:
-        for bit_number, atom_info in zip(plec, bit_info_content):
+        # sort bit info according to folded PLEC
+        sorted_bit_info_content = [bit_info_content[i] for i in sort_indexes]
+        for bit_number, atom_info in zip(plec, sorted_bit_info_content):
             if bit_number not in bits_info:
                 bits_info[bit_number] = set()
             bits_info[bit_number].add(atom_info)

--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -766,6 +766,10 @@ def similarity_SPLIF(reference, query, rmsd_cutoff=1.):
         return np.sqrt((numla / nula) * (numpa / nupa))
 
 
+PLEC_bit_info_record = namedtuple('PLEC_bit_info_record',
+                                  'ligand_root_atom_idx ligand_depth protein_root_atom_idx protein_depth')
+
+
 def PLEC(ligand, protein, depth_ligand=2, depth_protein=4, distance_cutoff=4.5,
          size=16384, count_bits=True, sparse=True, ignore_hoh=True, bits_info=None):
     """Protein ligand extended connectivity fingerprint. For every pair of
@@ -812,8 +816,7 @@ def PLEC(ligand, protein, depth_ligand=2, depth_protein=4, distance_cutoff=4.5,
     """
     result = []
     bit_info_content = []
-    plec_bit_info_record = namedtuple('PLEC_bit_info_record',
-                                      'ligand_root_atom_idx ligand_depth protein_root_atom_idx protein_depth')
+
     # removing h
     protein_mask = protein_no_h = (protein.atom_dict['atomicnum'] != 1)
     if ignore_hoh:
@@ -855,7 +858,7 @@ def PLEC(ligand, protein, depth_ligand=2, depth_protein=4, distance_cutoff=4.5,
                 enumerate(ligand_ecfp), enumerate(protein_ecfp), fillvalue=fillvalue):
             result.append(hash32((ligand_bit, protein_bit)))
             if bits_info is not None:
-                bit_info_content.append(plec_bit_info_record(
+                bit_info_content.append(PLEC_bit_info_record(
                     ligand_root_atom_idx=ligand_atom,
                     ligand_depth=ligand_depth,
                     protein_root_atom_idx= protein_atom,

--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -378,6 +378,60 @@ else:
         return hash_value & max_uint_mask
 
 
+def get_atom_environments(mol, root_atom_idx, depth):
+    """Get circular environments of atom indices up to certain depth.
+    Atoms from each depth are kept separate.
+    BFS search is done until atom outside of given depth is found.
+
+    Parameters
+    ----------
+    mol : oddt.toolkit.Molecule object
+        Molecule object containing environments
+
+    root_atom_idx : int
+        0-based index of root atom for all environments
+
+    depth : int
+        Maximum depth of environments to return
+
+    Returns
+    -------
+    envs: list (size = depth + 1)
+        List of atoms at each respective environment depth
+    """
+
+    if is_openbabel_molecule(mol):
+        envs = OrderedDict([(i, []) for i in range(depth + 1)])
+        last_depth = 0
+        for atom, current_depth in oddt.toolkits.ob.ob.OBMolAtomBFSIter(mol.OBMol,
+                                                                        root_atom_idx + 1):
+            # FIX for disconnected fragments in OB
+            if ((current_depth > depth + 1) or
+                    (last_depth > current_depth) or
+                    (last_depth == 1 and current_depth == 1)):
+                break
+            last_depth = current_depth
+            if atom.GetAtomicNum() == 1:
+                continue
+            envs[current_depth - 1].append(atom.GetIdx() - 1)
+        envs = list(envs.values())
+    else:
+        envs = [[root_atom_idx]]
+        visited = [root_atom_idx]
+        for r in range(1, depth + 1):
+            current_depth_atoms = []
+            for atom_idx in envs[r - 1]:
+                for neighbor in mol.Mol.GetAtomWithIdx(atom_idx).GetNeighbors():
+                    if neighbor.GetAtomicNum() == 1:
+                        continue
+                    n_idx = neighbor.GetIdx()
+                    if n_idx not in visited and n_idx not in current_depth_atoms:
+                        current_depth_atoms.append(n_idx)
+                        visited.append(n_idx)
+            envs.append(current_depth_atoms)
+    return envs
+
+
 def _ECFP_atom_repr(mol, idx, use_pharm_features=False):
     """Simple description of atoms used in ECFP/FCFP. Bonds are not described
     accounted for. Hydrogens are explicitly forbidden, they raise Exception.
@@ -488,36 +542,7 @@ def _ECFP_atom_hash(mol, idx, depth=2, use_pharm_features=False,
     environment_hashes : list of ints
         Hashed environments for certain atom
     """
-    if is_openbabel_molecule(mol):
-        envs = OrderedDict([(i, []) for i in range(depth + 1)])
-        last_depth = 0
-        for atom, current_depth in oddt.toolkits.ob.ob.OBMolAtomBFSIter(mol.OBMol,
-                                                                        idx + 1):
-            # FIX for disconnected fragments in OB
-            if ((current_depth > depth + 1) or
-                    (last_depth > current_depth) or
-                    (last_depth == 1 and current_depth == 1)):
-                break
-            last_depth = current_depth
-            if atom.GetAtomicNum() == 1:
-                continue
-            envs[current_depth - 1].append(atom.GetIdx() - 1)
-        envs = list(envs.values())
-    else:
-        envs = [[idx]]
-        visited = [idx]
-        for r in range(1, depth + 1):
-            tmp = []
-            for atom_idx in envs[r - 1]:
-                for neighbor in mol.Mol.GetAtomWithIdx(atom_idx).GetNeighbors():
-                    if neighbor.GetAtomicNum() == 1:
-                        continue
-                    n_idx = neighbor.GetIdx()
-                    if n_idx not in visited and n_idx not in tmp:
-                        tmp.append(n_idx)
-                        visited.append(n_idx)
-            envs.append(tmp)
-
+    envs = get_atom_environments(mol, root_atom_idx=idx, depth=depth)
     atom_env = []
     for r in range(1, depth + 2):  # there are depth + 1 elements, so +2
         atom_env.append(list(chain(*envs[:r])))

--- a/oddt/fingerprints.py
+++ b/oddt/fingerprints.py
@@ -864,17 +864,18 @@ def PLEC(ligand, protein, depth_ligand=2, depth_protein=4, distance_cutoff=4.5,
 
     # folding and sorting
     plec = fold(np.array(result), size=size)
-    sort_indexes = np.argsort(plec)
-    plec = plec[sort_indexes].astype(np.min_scalar_type(size))
 
     # add bits info after folding
     if bits_info is not None:
+        sort_indexes = np.argsort(plec)
+        plec = plec[sort_indexes].astype(np.min_scalar_type(size))
         # sort bit info according to folded PLEC
-        sorted_bit_info_content = [bit_info_content[i] for i in sort_indexes]
-        for bit_number, atom_info in zip(plec, sorted_bit_info_content):
+        for bit_number, bit_info_idx in zip(plec, sort_indexes):
             if bit_number not in bits_info:
                 bits_info[bit_number] = set()
-            bits_info[bit_number].add(atom_info)
+            bits_info[bit_number].add(bit_info_content[bit_info_idx])
+    else:
+        plec = np.sort(plec).astype(np.min_scalar_type(size))
 
     # count_bits
     if not count_bits:


### PR DESCRIPTION
Addresses #118 

@luponzo86 Could you check if this branch works for you? The return API has not changed the `bits_info` dictionary is modified in-place, so you need to feed an instance to PLEC fp.

```python
bits_info = {}
PLEC(ligand, protein, bits_info=bits_info)
print(bits_info)
```

The dictionary contains mapping between bits and ligand/protein root atom IDXs plus the depths. Let me know what you think about this capability.